### PR TITLE
[Feat/layout] 페이지 그룹별 전역 레이아웃 적용

### DIFF
--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,0 +1,3 @@
+export default function Admin() {
+    return <main>관리자 페이지</main>;
+  }

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,0 +1,9 @@
+import AdminGlobalLayout from "@/components/AdminGlobalLayout";
+
+export default function AdminLayout({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return <AdminGlobalLayout>{children}</AdminGlobalLayout>;
+  }

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,4 +1,5 @@
-import UserLayout from "@/components/UserLayout";
+import UserGlobalLayout from "@/components/UserGlobalLayout";
+
 
 export default function AuthLayout({
   children,
@@ -6,6 +7,6 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <UserLayout>{children}</UserLayout>
+    <UserGlobalLayout>{children}</UserGlobalLayout>
   );
 }

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,13 +1,11 @@
+import UserLayout from "@/components/UserLayout";
+
 export default function AuthLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex justify-center items-center min-h-screen bg-gray-200">
-      <div className="w-full max-w-[480px] min-h-screen bg-white shadow-md overflow-hidden flex flex-col items-center justify-center">
-        {children}
-      </div>
-    </div>
+    <UserLayout>{children}</UserLayout>
   );
 }

--- a/src/app/(user)/layout.tsx
+++ b/src/app/(user)/layout.tsx
@@ -1,0 +1,11 @@
+import UserGlobalLayout from "@/components/UserGlobalLayout";
+
+export default function UserLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <UserGlobalLayout>{children}</UserGlobalLayout>
+  );
+}

--- a/src/app/(user)/user/page.tsx
+++ b/src/app/(user)/user/page.tsx
@@ -1,0 +1,3 @@
+export default function UserPage() {
+    return <main>학생용 페이지</main>;
+  }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,11 +38,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="flex justify-center items-center min-h-screen bg-gray-200">
-        <div className="w-full max-w-[480px] min-h-screen bg-white shadow-md overflow-hidden flex flex-col items-center justify-center">
-          {children}
-        </div>
-      </body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,11 @@
 import Splash from "@/components/Splash";
 import { Button } from "@/components/ui/button";
+import UserGlobalLayout from "@/components/UserGlobalLayout";
 import Image from "next/image";
 
 export default function Home() {
   return (
+    <UserGlobalLayout>
     <main className="w-full h-screen flex flex-col justify-between items-center bg-white ">
       <Splash />
       <div className="text-center pt-[160px]">
@@ -22,5 +24,6 @@ export default function Home() {
         </Button>
       </div>
     </main>
+    </UserGlobalLayout>
   );
 }

--- a/src/components/AdminGlobalLayout.tsx
+++ b/src/components/AdminGlobalLayout.tsx
@@ -1,0 +1,7 @@
+export default function AdminGlobalLayout({ children }: { children: React.ReactNode }) {
+    return (
+      <div>
+          {children}
+      </div>
+    );
+  }

--- a/src/components/UserGlobalLayout.tsx
+++ b/src/components/UserGlobalLayout.tsx
@@ -1,4 +1,4 @@
-export default function UserLayout({ children }: { children: React.ReactNode }) {
+export default function UserGloabalLayout({ children }: { children: React.ReactNode }) {
     return (
       <div className="flex justify-center items-center min-h-screen bg-gray-200">
         <div className="w-full max-w-[480px] min-h-screen bg-white shadow-md overflow-hidden flex flex-col items-center justify-center">

--- a/src/components/UserLayout.tsx
+++ b/src/components/UserLayout.tsx
@@ -1,0 +1,9 @@
+export default function UserLayout({ children }: { children: React.ReactNode }) {
+    return (
+      <div className="flex justify-center items-center min-h-screen bg-gray-200">
+        <div className="w-full max-w-[480px] min-h-screen bg-white shadow-md overflow-hidden flex flex-col items-center justify-center">
+          {children}
+        </div>
+      </div>
+    );
+  }


### PR DESCRIPTION
## 💡 구현 목적
- (auth), (user), (admin) 그룹별로 적절한 레이아웃 컴포넌트를 적용할 수 있도록 레이아웃 구조 개선

## 🗝️ 핵심 변경사항
1. `RootLayout` 을 최소화하여 기본 메타데이터와 뷰포트 설정만 포함하도록 수정
2. `UserGlobalLayout` 컴포넌트 생성하여 (auth)와 (user) 그룹의 모바일 레이아웃 통합
3. `AdminGlobalLayout` 컴포넌트 생성하여 추후 관리자 페이지를 위한 PC 레이아웃 적용 가능하도록 
4. (user)와 (admin) 부분 layout.tsx와 page.tsx이 비어있어서 임시로 기본 컴포넌트 작성

## ⭐ 구현 결과
- 기존 화면 UI 변경 없이 레이아웃 구조만 개선 
<img width="299" alt="image" src="https://github.com/user-attachments/assets/74f4e91e-6add-4216-a600-e8cf02b7bfc0">
<img width="297" alt="image" src="https://github.com/user-attachments/assets/14d43f95-4a0a-40e7-8af4-748b6cb47785">

## 🧐 추가 논의 사항
- 제대로 작동하는지 테스트는 완료했으나 혹시 기존 UI와 다르게 보이는 부분이 있을 경우 코멘트 부탁드립니다:) 