### PR TITLE
feat: 어드민 페이지 레이아웃 구성

### DIFF
--- a/src/app/(admin)/admin/drawManage/claim/page.tsx
+++ b/src/app/(admin)/admin/drawManage/claim/page.tsx
@@ -1,0 +1,3 @@
+export default function Admin() {
+  return <main>수령</main>;
+}

--- a/src/app/(admin)/admin/drawManage/draw/page.tsx
+++ b/src/app/(admin)/admin/drawManage/draw/page.tsx
@@ -1,0 +1,3 @@
+export default function Admin() {
+  return <main>추첨</main>;
+}

--- a/src/app/(admin)/admin/drawManage/page.tsx
+++ b/src/app/(admin)/admin/drawManage/page.tsx
@@ -1,0 +1,3 @@
+export default function Admin() {
+  return <main>추첨 관리</main>;
+}

--- a/src/app/(admin)/admin/drawManage/winners/page.tsx
+++ b/src/app/(admin)/admin/drawManage/winners/page.tsx
@@ -1,0 +1,3 @@
+export default function Admin() {
+  return <main>당첨 확인</main>;
+}

--- a/src/app/(admin)/admin/participation/page.tsx
+++ b/src/app/(admin)/admin/participation/page.tsx
@@ -1,0 +1,3 @@
+export default function Admin() {
+  return <main>참여자 관리</main>;
+}

--- a/src/app/(admin)/admin/programManage/page.tsx
+++ b/src/app/(admin)/admin/programManage/page.tsx
@@ -1,0 +1,3 @@
+export default function Admin() {
+  return <main>프로그램 관리</main>;
+}

--- a/src/app/(admin)/admin/userManage/page.tsx
+++ b/src/app/(admin)/admin/userManage/page.tsx
@@ -1,0 +1,3 @@
+export default function Admin() {
+  return <main>유저관리</main>;
+}

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,9 +1,17 @@
 import AdminGlobalLayout from "@/components/AdminGlobalLayout";
+import Sidebar from "@/components/Sidebar";
 
 export default function AdminLayout({
-    children,
-  }: {
-    children: React.ReactNode;
-  }) {
-    return <AdminGlobalLayout>{children}</AdminGlobalLayout>;
-  }
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <AdminGlobalLayout>
+      <div className="flex">
+        <Sidebar />
+        <main className="flex-1 p-4">{children}</main>
+      </div>
+    </AdminGlobalLayout>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import React from "react";
+import {
+  Users,
+  Folder,
+  Calendar,
+  Target,
+  BookOpen,
+  LogOut,
+} from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const Sidebar = () => {
+  return (
+    <nav className="bg-[#235698] text-white w-64 min-h-screen p-4 flex flex-col justify-between">
+      <div>
+        <div className="text-2xl font-bold mb-6 text-center">chekirout</div>
+        <ul>
+          <SidebarItem
+            icon={<Users size={20} />}
+            title="유저 관리"
+            href="/admin/userManage"
+          />
+          <SidebarItem
+            icon={<Folder size={20} />}
+            title="프로그램 관리"
+            href="/admin/programManage"
+          />
+          <SidebarItem
+            icon={<Calendar size={20} />}
+            title="참여 기록 관리"
+            href="/admin/participation"
+          />
+          <SidebarItem
+            icon={<Target size={20} />}
+            title="추첨 대상 관리"
+            href="/admin/drawManage">
+            <SubItem title="추첨" href="/admin/drawManage/draw" />
+            <SubItem title="당첨자 확인" href="/admin/drawManage/winners" />
+            <SubItem title="수령 확인" href="/admin/drawManage/claim" />
+          </SidebarItem>
+        </ul>
+      </div>
+      <div>
+        <ul>
+          <SidebarItem
+            icon={<BookOpen size={20} />}
+            title="학생용 페이지"
+            href="/user"
+          />
+          <SidebarItem icon={<LogOut size={20} />} title="로그아웃" href="/" />
+        </ul>
+      </div>
+    </nav>
+  );
+};
+
+interface SidebarItemProps {
+  icon: React.ReactNode;
+  title: string;
+  href: string;
+  children?: React.ReactNode;
+}
+
+const SidebarItem: React.FC<SidebarItemProps> = ({
+  icon,
+  title,
+  href,
+  children,
+}) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const pathname = usePathname();
+  const isActive = pathname === href || pathname.startsWith(`${href}/`);
+
+  return (
+    <li className="mb-4">
+      <Link href={href} passHref>
+        <button
+          className={`flex items-center w-full text-left ${
+            isActive ? "bg-white bg-opacity-20" : ""
+          } p-2 rounded`}
+          onClick={(e) => {
+            if (children) {
+              e.preventDefault();
+              setIsOpen(!isOpen);
+            }
+          }}>
+          {icon}
+          <span className="ml-2">{title}</span>
+        </button>
+      </Link>
+      {children && isOpen && <ul className="ml-4 mt-2">{children}</ul>}
+    </li>
+  );
+};
+
+interface SubItemProps {
+  title: string;
+  href: string;
+}
+
+const SubItem: React.FC<SubItemProps> = ({ title, href }) => {
+  const pathname = usePathname();
+  const isActive = pathname === href;
+
+  return (
+    <li className="my-2">
+      <Link
+        href={href}
+        className={`text-sm hover:text-gray-300 ${
+          isActive ? "font-bold" : ""
+        }`}>
+        {title}
+      </Link>
+    </li>
+  );
+};
+
+export default Sidebar;


### PR DESCRIPTION
## 💡 구현 목적
페이지 퍼블리싱

## 🗝️ 핵심 변경사항
- 사이드바 컴포넌트 구현, 어드민 레이아웃에 적용
- 어드민 페이지 경로 구성

## ⭐ 구현 결과
![image](https://github.com/user-attachments/assets/80321927-ec6a-4a9c-a34e-024d6c318f93)

사이드바 메뉴는 유저관리, 프로그램 관리, 참여 기록 관리, 추첨 대상 관리(추첨, 당첨자 확인, 수령 확인), 학생용 페이지로 이동, 로그아웃으로 구성되며 각 메뉴 선택 시

- /admin/userManage
- /admin/programManage
- /admin/participation
- /admin/drawMange/draw, winners, claim
- /user
- /

이로 이동한다.

## 🦊반성문
이전 publishing 브랜치 pr 후 develop 브랜치에서 전환않고 개발하다가 develop에 바로 커밋 날렸읍니다...죄송합니다...
