### PR TITLE
[Feature] 로그인 및 마이페이지 정보 조회 API 연동 

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -42,7 +42,7 @@ export default function LoginPage() {
     setIsLoading(true);
     try {
       const response = await axios.post(
-        "http://ec2-15-165-241-189.ap-northeast-2.compute.amazonaws.com:8080/api/v1/login",
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/login`,
         {
           username: data.username,
           password: data.password,
@@ -51,7 +51,6 @@ export default function LoginPage() {
 
       if (response.status === 200) {
         console.log("로그인 성공");
-        // console.log(response.data);
         localStorage.setItem("accessToken", response.data.accessToken); 
         localStorage.setItem("refreshToken", response.data.refreshToken);
          router.push("/home"); 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -14,6 +14,9 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import axios from "axios";
 
 const FormSchema = z.object({
   username: z.string().min(8, {
@@ -25,6 +28,8 @@ const FormSchema = z.object({
 });
 
 export default function LoginPage() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
@@ -33,10 +38,31 @@ export default function LoginPage() {
     },
   });
 
-  function onSubmit(data: z.infer<typeof FormSchema>) {
-    console.log("로그인 시도");
-  }
+  async function onSubmit(data: z.infer<typeof FormSchema>) {
+    setIsLoading(true);
+    try {
+      const response = await axios.post(
+        "http://ec2-15-165-241-189.ap-northeast-2.compute.amazonaws.com:8080/api/v1/login",
+        {
+          username: data.username,
+          password: data.password,
+        }
+      );
 
+      if (response.status === 200) {
+        console.log("로그인 성공");
+        console.log(response.data);
+        localStorage.setItem("accessToken", response.data.accessToken); 
+        localStorage.setItem("refreshToken", response.data.refreshToken);
+        router.push("/user/mypage"); 
+      }
+    } catch (error) {
+      console.error("로그인 오류:", error);
+      console.log("로그인 중 오류가 발생했습니다. 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
   return (
     <main className="w-[480px] h-screen flex flex-col items-center bg-white">
       <div className="text-center pt-[200px] mb-20">

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -51,10 +51,10 @@ export default function LoginPage() {
 
       if (response.status === 200) {
         console.log("로그인 성공");
-        console.log(response.data);
+        // console.log(response.data);
         localStorage.setItem("accessToken", response.data.accessToken); 
         localStorage.setItem("refreshToken", response.data.refreshToken);
-        router.push("/user/mypage"); 
+         router.push("/home"); 
       }
     } catch (error) {
       console.error("로그인 오류:", error);

--- a/src/app/(user)/home/page.tsx
+++ b/src/app/(user)/home/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 
 const Stamp = ({ size = 48 }: { size?: number }) => (
     <svg width={size} height={size} viewBox="0 0 55 55" fill="none" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
@@ -21,7 +22,15 @@ const EmptyStamp = ({ size = 43 }: { size?: number }) => (
 );
 
 export default function HomePage() {
+    const router = useRouter();
     const [hoveredStamp, setHoveredStamp] = useState<number | null>(null);
+    
+    useEffect(() => {
+        const accessToken = localStorage.getItem("accessToken");
+        if (!accessToken) {
+            router.push("/login");
+        }
+    }, [router]);
     
     const stamps = [
         { id: 1, completed: true, info: "전문가 특강" },

--- a/src/app/(user)/user/mypage/page.tsx
+++ b/src/app/(user)/user/mypage/page.tsx
@@ -25,13 +25,8 @@ export default function MyPage() {
       router.push("/login");
       return;
     }
+
     const fetchUserInfo = async () => {
-      const accessToken = localStorage.getItem("accessToken");
-      if (!accessToken) {
-        router.push("/login");
-        return;
-      }
-    
       try {
         const response = await axios.get(
           "http://ec2-15-165-241-189.ap-northeast-2.compute.amazonaws.com:8080/api/v1/users/profile",

--- a/src/app/(user)/user/mypage/page.tsx
+++ b/src/app/(user)/user/mypage/page.tsx
@@ -29,7 +29,7 @@ export default function MyPage() {
     const fetchUserInfo = async () => {
       try {
         const response = await axios.get(
-          "http://ec2-15-165-241-189.ap-northeast-2.compute.amazonaws.com:8080/api/v1/users/profile",
+          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/users/profile`,
           {
             headers: {
               Authorization: `Bearer ${accessToken}`,

--- a/src/app/(user)/user/mypage/page.tsx
+++ b/src/app/(user)/user/mypage/page.tsx
@@ -1,24 +1,65 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 import { Edit } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import axios from "axios";
+
+interface UserInfo {
+  name: string;   
+  department: string;   
+  studentId: string;  
+}
 
 export default function MyPage() {
-  // 임시데이터
-  const userInfo = {
-    name: "황다경",
-    department: "컴퓨터소프트웨어공학과 ",
-    studentId: "20204023",
-  };
+  const router = useRouter();
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
+  useEffect(() => {
+    const accessToken = localStorage.getItem("accessToken");
+    if (!accessToken) {
+      router.push("/login");
+      return;
+    }
+    const fetchUserInfo = async () => {
+      const accessToken = localStorage.getItem("accessToken");
+      if (!accessToken) {
+        router.push("/login");
+        return;
+      }
+    
+      try {
+        const response = await axios.get(
+          "http://ec2-15-165-241-189.ap-northeast-2.compute.amazonaws.com:8080/api/v1/users/profile",
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        );
+        setUserInfo(response.data);
+      } catch (error) {
+        console.error("사용자 정보 조회 실패:", error);
+        router.push("/login");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchUserInfo();
+  }, [router]);
+  
   return (
     <main className="relative flex flex-col items-center">
       <div className="relative">
         <Image src="/assets/Card.png" alt="카드" width={332} height={480} />
         <div className="absolute top-4 right-4 text-right text-white">
-          <p className="font-bold text-2xl">{userInfo.name}</p>
-          <p className="text-base">{userInfo.department}</p>
-          <p className="text-base">{userInfo.studentId}</p>
+          <p className="font-bold text-2xl">{userInfo?.name}</p>
+          <p className="text-base">{userInfo?.department}</p>
+          <p className="text-base">{userInfo?.studentId}</p>
         </div>
       </div>
       <Link href="/user/mypage/edit" passHref>


### PR DESCRIPTION
## 💡 구현 목적
백엔드 API와 연동하여 로그인 / 마이페이지 데이터 통신 확인

## 🗝️ 핵심 변경사항
1. 로그인 API 연동
  - 사용자 입력 정보를 백엔드 API로 전송하여 인증
  - 인증 성공 시 JWT 토큰을 로컬 스토리지에 저장
2. 마이페이지 API 연동 
  - JWT 토큰을 사용하여 사용자 정보 조회 API 호출
  - 프로필 카드에 사용자 정보 표시
3. 환경 변수를 사용하여 API URL 관리

## ⭐ 구현 결과
<img width="250" alt="image" src="https://github.com/user-attachments/assets/602d8a53-99b7-4db6-90b1-f9baa35f78f3">

## 🧐 추가 논의 사항
- 현재는 토큰 만료 시 로그인 페이지로 리다이렉트하고 있는데, Refresh 토큰을 활용한 자동 갱신 방식으로 변경해야함
- JWT 토큰을 계속 로컬스토리지에 저장할것인지 검토 필요 
- API 호출 로직을 별도 파일로 분리하는 것 고려중