### PR TITLE
[Refactor] 로그인 로직 분리 및 모듈화

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,14 @@
+import axios from "axios";
+
+export const login = async (username: string, password: string) => {
+  return axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/login`, {
+    username,
+    password,
+  });
+};
+
+export const refreshToken = async (refreshToken: string) => {
+  return axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/refresh-token`, {
+    refreshToken,
+  });
+};

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -13,14 +13,14 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { setupAxiosInterceptors } from "@/lib/axiosInterceptor";
 import { LoginFormSchema, LoginFormData } from "@/schemas/loginSchema";
-import { login } from "@/api/auth";
+import { useLogin } from "@/hooks/useLogin";
 
 export default function LoginPage() {
   const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
+  const { handleLogin, isLoading } = useLogin();
 
   const form = useForm<LoginFormData>({
     resolver: zodResolver(LoginFormSchema),
@@ -34,24 +34,6 @@ export default function LoginPage() {
     setupAxiosInterceptors(router);
   }, [router]);
 
-  async function onSubmit(data: LoginFormData) {
-    setIsLoading(true);
-    try {
-      const response = await login(data.username, data.password);
-      if (response.status === 200) {
-        console.log("로그인 성공");
-        localStorage.setItem("accessToken", response.data.accessToken);
-        localStorage.setItem("refreshToken", response.data.refreshToken);
-        router.push("/home");
-      }
-    } catch (error) {
-      console.error("로그인 오류:", error);
-      console.log("로그인 중 오류가 발생했습니다. 다시 시도해주세요.");
-    } finally {
-      setIsLoading(false);
-    }
-  }
-
   return (
     <main className="w-[480px] h-screen flex flex-col items-center bg-white">
       <div className="text-center pt-[200px] mb-20">
@@ -60,7 +42,7 @@ export default function LoginPage() {
 
       <Form {...form}>
         <form
-          onSubmit={form.handleSubmit(onSubmit)}
+          onSubmit={form.handleSubmit(handleLogin)}
           className="w-[328px] space-y-6">
           <FormField
             control={form.control}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,8 +2,6 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import { z } from "zod";
-
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -17,23 +15,15 @@ import { Input } from "@/components/ui/input";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { setupAxiosInterceptors } from "@/lib/axiosInterceptor";
-import { LoginFormData } from "@/schemas/loginSchema";
+import { LoginFormSchema, LoginFormData } from "@/schemas/loginSchema";
 import { login } from "@/api/auth";
-
-const FormSchema = z.object({
-  username: z.string().min(8, {
-    message: "학번 8자리를 입력해주세요.",
-  }),
-  password: z.string().min(6, {
-    message: "비밀번호는 최소 8자 이상이어야 합니다.",
-  }),
-});
 
 export default function LoginPage() {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
+
+  const form = useForm<LoginFormData>({
+    resolver: zodResolver(LoginFormSchema),
     defaultValues: {
       username: "",
       password: "",

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { login } from '@/api/auth';
+import { LoginFormData } from '@/schemas/loginSchema';
+
+export function useLogin() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleLogin = async (data: LoginFormData) => {
+    setIsLoading(true);
+    try {
+      const response = await login(data.username, data.password);
+      if (response.status === 200) {
+        console.log("로그인 성공");
+        localStorage.setItem("accessToken", response.data.accessToken);
+        localStorage.setItem("refreshToken", response.data.refreshToken);
+        router.push("/home");
+      }
+    } catch (error) {
+      console.error("로그인 오류:", error);
+      console.log("로그인 중 오류가 발생했습니다. 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { handleLogin, isLoading };
+}

--- a/src/lib/axiosInterceptor.ts
+++ b/src/lib/axiosInterceptor.ts
@@ -1,0 +1,34 @@
+import axios from "axios";
+import { refreshToken } from "@/api/auth";
+
+export const setupAxiosInterceptors = (router: any) => {
+  axios.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+      const originalRequest = error.config;
+      if (error.response.status === 401 && !originalRequest._retry) {
+        originalRequest._retry = true;
+        try {
+          const storedRefreshToken = localStorage.getItem("refreshToken");
+          const refreshResponse = await refreshToken(storedRefreshToken!);
+          const newAccessToken = refreshResponse.data.accessToken;
+          
+          if (newAccessToken) {
+            localStorage.setItem("accessToken", newAccessToken);
+            axios.defaults.headers.common['Authorization'] = `Bearer ${newAccessToken}`;
+            return axios(originalRequest);
+          } else {
+            throw new Error("New access token not received");
+          }
+        } catch (refreshError) {
+          console.error("토큰 갱신 실패:", refreshError);
+          localStorage.removeItem("accessToken");
+          localStorage.removeItem("refreshToken");
+          router.push("/login");
+          return Promise.reject(refreshError);
+        }
+      }
+      return Promise.reject(error);
+    }
+  );
+};

--- a/src/schemas/loginSchema.ts
+++ b/src/schemas/loginSchema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const LoginFormSchema = z.object({
+  username: z.string().min(8, {
+    message: "학번 8자리를 입력해주세요.",
+  }),
+  password: z.string().min(6, {
+    message: "비밀번호는 최소 8자 이상이어야 합니다.",
+  }),
+});
+
+export type LoginFormData = z.infer<typeof LoginFormSchema>;


### PR DESCRIPTION
## 구현 목적 
코드의 모듈화 및 구조 개선을 통한 유지보수성 향상

## 핵심 변경사항 
1. axios 인터셉터를 통한 자동 토큰 갱신 로직 추가
2. 기능별 파일 분리 -  (로그인 폼 스키마, API, 인터셉터, 컴포넌트)

## 구현 결과
- 길어지는 로그인 페이지를 기능별로 로직 분리만 해줬기 때문에 UI 변경사항 X
- 기존과 마찬가지로 로그인 & 마이페이지 API 연동 테스트 완료 (문제없음)

## 전달사항 
- 로그인 폼 스키마 - `src/schemas/loginSchema.ts`
- API 호출 함수  - `src/api/auth.ts`
- 토큰 갱신 관련 인터셉터 - `src/utils/axiosInterceptor.ts`
- 로그인 로직을 포함한 커스텀 훅 - `src/hooks/useLogin.ts`