### PR TITLE
[Feature] 정보 수정 페이지에서 비밀번호 변경 기능 구현

### DIFF
--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
 import { TextField, PasswordField, SelectField } from "@/components/FormField";
+import { departments } from "@/constants/constants";
 
 const FormSchema = z
   .object({
@@ -27,15 +28,6 @@ const FormSchema = z
     message: "비밀번호가 일치하지 않습니다.",
     path: ["confirmPassword"],
   });
-
-const departments = [
-  { label: "컴퓨터소프트웨어공학과", value: "CSE" },
-  { label: "의료 IT공학과", value: "MEDIT" },
-  { label: "정보보호학과", value: "IP" },
-  { label: "사물인터넷학과", value: "IoT" },
-  { label: "메타버스게임학과", value: "METABUS" },
-  { label: "AI빅데이터공학과", value: "AI_BIGDATA" },
-];
 
 export default function SignupPage() {
   const router = useRouter();

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -10,42 +10,25 @@ import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
 import { TextField, PasswordField, SelectField } from "@/components/FormField";
 import { departments } from "@/constants/constants";
-
-const FormSchema = z
-  .object({
-    studentId: z.string().length(8, {
-      message: "학번 8자리를 입력해주세요.",
-    }),
-    department: z.string().min(1, "학과를 선택해주세요"),
-    name: z.string().min(1, "이름을 입력해주세요"),
-    password: z.string().min(6, {
-      message: "비밀번호는 최소 6자 이상이어야 합니다.",
-    }),
-    confirmPassword: z.string(),
-    userType: z.enum(["STUDENT", "ADMIN"]),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: "비밀번호가 일치하지 않습니다.",
-    path: ["confirmPassword"],
-  });
+import { SigninSchema, SigninFormData } from "@/schemas/signinSchema";
 
 export default function SignupPage() {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
 
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
+  const form = useForm<SigninFormData>({
+    resolver: zodResolver(SigninSchema),
     defaultValues: {
-      studentId: "",
+      username: "",
       department: "",
       name: "",
       password: "",
       confirmPassword: "",
-      userType: "STUDENT",
+      role: "STUDENT",
     },
   });
 
-  async function onSubmit(data: z.infer<typeof FormSchema>) {
+  async function onSubmit(data: SigninFormData) {
     setIsLoading(true);
     try {
       const selectedDepartment = departments.find(
@@ -54,11 +37,11 @@ export default function SignupPage() {
       const response = await axios.post(
         "http://ec2-15-165-241-189.ap-northeast-2.compute.amazonaws.com:8080/api/v1/signup",
         {
-          username: data.studentId,
+          username: data.username,
           department: selectedDepartment ? selectedDepartment.value : "",
           name: data.name,
           password: data.password,
-          role: data.userType,
+          role: "STUDENT",
         }
       );
 
@@ -86,7 +69,7 @@ export default function SignupPage() {
           className="w-[328px] space-y-6 mb-10">
           <TextField
             control={form.control}
-            name="studentId"
+            name="username"
             label="학번"
             placeholder="학번을 입력하세요"
           />
@@ -115,29 +98,7 @@ export default function SignupPage() {
             label="비밀번호 확인"
             placeholder="비밀번호를 다시 입력하세요"
           />
-          <div className="w-[328px]">
-            <div className="text-sm mb-2">사용자 유형</div>
-            <div className="flex space-x-4">
-              <Button
-                type="button"
-                variant={
-                  form.watch("userType") === "STUDENT" ? "default" : "outline"
-                }
-                onClick={() => form.setValue("userType", "STUDENT")}
-                className="flex-1 bg-gray-200 text-black hover:bg-gray-300">
-                일반
-              </Button>
-              <Button
-                type="button"
-                variant={
-                  form.watch("userType") === "ADMIN" ? "default" : "outline"
-                }
-                onClick={() => form.setValue("userType", "ADMIN")}
-                className="flex-1 bg-gray-200 text-black hover:bg-gray-300">
-                관리자
-              </Button>
-            </div>
-          </div>
+
           <Button
             type="submit"
             className="w-[328px] h-11 bg-[#235698] text-white font-semibold rounded-lg"

--- a/src/app/(user)/layout.tsx
+++ b/src/app/(user)/layout.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { usePathname } from "next/navigation";
 import BottomNav from "@/components/BottonNav";
 import FloatingQRButton from "@/components/FloatingQRButton";
 import TopNav from "@/components/TopNav";
@@ -8,12 +11,17 @@ export default function UserLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const pathname = usePathname();
+  const hideFloatingQRButton =
+    pathname === "/user/mypage" || pathname === "/user/mypage/edit";
+  const hideNav = pathname === "/user/mypage/edit";
+
   return (
     <UserGlobalLayout>
       <TopNav />
       {children}
-      <FloatingQRButton />
-      <BottomNav />
+      {!hideFloatingQRButton && <FloatingQRButton />}
+      {!hideNav && <BottomNav />}
     </UserGlobalLayout>
   );
 }

--- a/src/app/(user)/user/mypage/edit/page.tsx
+++ b/src/app/(user)/user/mypage/edit/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -15,11 +15,13 @@ import {
   EditProfileFormData,
 } from "@/schemas/editProfileSchema";
 import { useUserInfo } from "@/hooks/useUserInfo";
+import axios from "axios";
 
 export default function EditMyPage() {
   const router = useRouter();
   const { toast } = useToast();
   const { userInfo, isLoading } = useUserInfo();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const form = useForm<EditProfileFormData>({
     resolver: zodResolver(EditProfileSchema),
@@ -59,13 +61,118 @@ export default function EditMyPage() {
     return <div>로딩 중...</div>;
   }
 
-  function onSubmit(values: EditProfileFormData) {
-    console.log(values);
-    toast({
-      title: "정보가 수정되었습니다.",
-      description: "변경사항이 성공적으로 저장되었습니다.",
-    });
-    router.push("/user/mypage");
+  async function onSubmit(values: EditProfileFormData) {
+    setIsSubmitting(true);
+    try {
+      if (values.newPassword || values.currentPassword) {
+        if (!values.currentPassword) {
+          form.setError("currentPassword", {
+            type: "manual",
+            message: "현재 비밀번호를 입력해주세요.",
+          });
+          setIsSubmitting(false);
+
+          return;
+        }
+
+        if (values.newPassword) {
+          if (values.currentPassword === values.newPassword) {
+            form.setError("newPassword", {
+              type: "manual",
+              message: "새로운 비밀번호를 입력해주세요.",
+            });
+            setIsSubmitting(false);
+            return;
+          }
+
+          if (values.newPassword.length < 8) {
+            form.setError("newPassword", {
+              type: "manual",
+              message: "비밀번호는 8자리 이상이어야 합니다.",
+            });
+            setIsSubmitting(false);
+            return;
+          }
+
+          if (!values.confirmPassword) {
+            form.setError("confirmPassword", {
+              type: "manual",
+              message: "새로운 비밀번호 확인을 입력해주세요.",
+            });
+            setIsSubmitting(false);
+            return;
+          }
+
+          if (values.newPassword !== values.confirmPassword) {
+            form.setError("confirmPassword", {
+              type: "manual",
+              message: "비밀번호가 일치하지 않습니다. 다시 입력해주세요.",
+            });
+            setIsSubmitting(false);
+            return;
+          }
+
+          // 비밀번호 변경 API 호출
+          const accessToken = localStorage.getItem("accessToken");
+          try {
+            await axios.put(
+              `${process.env.NEXT_PUBLIC_API_URL}/api/v1/users/change-password`,
+              {
+                currentPassword: values.currentPassword,
+                newPassword: values.newPassword,
+              },
+              {
+                headers: {
+                  Authorization: `Bearer ${accessToken}`,
+                },
+              }
+            );
+          } catch (error) {
+            if (axios.isAxiosError(error) && error.response) {
+              if (error.response.status === 400) {
+                form.setError("currentPassword", {
+                  type: "manual",
+                  message:
+                    "현재 비밀번호가 일치하지 않습니다. 다시 입력해주세요.",
+                });
+              } else if (error.response.status === 403) {
+                toast({
+                  title: "권한이 없습니다.",
+                  description:
+                    "비밀번호 변경 권한이 없습니다. 관리자에게 문의해주세요.",
+                  variant: "destructive",
+                });
+              } else {
+                toast({
+                  title: "오류가 발생했습니다.",
+                  description: "잠시 후 다시 시도해주세요.",
+                  variant: "destructive",
+                });
+              }
+              setIsSubmitting(false);
+              return;
+            }
+            throw error;
+          }
+        }
+      }
+
+      // 다른 정보 업데이트 로직(api 아직 없음)
+      toast({
+        title: "정보가 수정되었습니다.",
+        description: "변경사항이 성공적으로 저장되었습니다.",
+      });
+      router.push("/user/mypage");
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: "오류가 발생했습니다.",
+        description: "잠시 후 다시 시도해주세요.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
   return (
@@ -122,14 +229,15 @@ export default function EditMyPage() {
 
           <Device control={form.control} />
 
-          <Button type="submit" className="w-full">
-            저장하기
+          <Button type="submit" className="w-full" disabled={isSubmitting}>
+            {isSubmitting ? "저장 중..." : "저장하기"}
           </Button>
           <Button
             type="button"
             variant="outline"
             className="w-full"
-            onClick={() => router.push("/user/mypage")}>
+            onClick={() => router.push("/user/mypage")}
+            disabled={isSubmitting}>
             취소
           </Button>
         </div>

--- a/src/app/(user)/user/mypage/edit/page.tsx
+++ b/src/app/(user)/user/mypage/edit/page.tsx
@@ -29,7 +29,7 @@ export default function EditMyPage() {
       name: userInfo?.name || "",
       email: userInfo?.email || "",
       phoneNumber: userInfo?.phoneNumber || "",
-      password: "",
+      currentPassword: "",
       newPassword: "",
       confirmPassword: "",
       devices: [""],
@@ -47,7 +47,7 @@ export default function EditMyPage() {
         name: userInfo.name,
         email: userInfo.email,
         phoneNumber: userInfo.phoneNumber,
-        password: "",
+        currentPassword: "",
         newPassword: "",
         confirmPassword: "",
         devices: [""],
@@ -103,7 +103,7 @@ export default function EditMyPage() {
           />
           <PasswordField
             control={form.control}
-            name="password"
+            name="currentPassword"
             label="현재 비밀번호"
             placeholder="현재 비밀번호"
           />
@@ -124,6 +124,13 @@ export default function EditMyPage() {
 
           <Button type="submit" className="w-full">
             저장하기
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={() => router.push("/user/mypage")}>
+            취소
           </Button>
         </div>
       </form>

--- a/src/app/(user)/user/mypage/edit/page.tsx
+++ b/src/app/(user)/user/mypage/edit/page.tsx
@@ -3,7 +3,6 @@
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import * as z from "zod";
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
 import { useToast } from "@/hooks/use-toast";

--- a/src/app/(user)/user/mypage/edit/page.tsx
+++ b/src/app/(user)/user/mypage/edit/page.tsx
@@ -5,28 +5,14 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { Button } from "@/components/ui/button";
-import {
-  Form,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormControl,
-  FormMessage,
-} from "@/components/ui/form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Form } from "@/components/ui/form";
 import { useToast } from "@/hooks/use-toast";
-import { TextField, PasswordField } from "@/components/FormField";
+import { TextField, PasswordField, SelectField } from "@/components/FormField";
 import { Device } from "@/components/Device";
-
+import { departments } from "@/constants/constants";
 const formSchema = z
   .object({
-    studentId: z.string(),
+    username: z.string(),
     department: z.string(),
     name: z.string(),
     email: z.string().email({ message: "유효한 이메일 주소를 입력해주세요." }),
@@ -47,41 +33,6 @@ const formSchema = z
     path: ["confirmPassword"],
   });
 
-const departments = [
-  "컴퓨터소프트웨어공학과",
-  "의료 IT공학과",
-  "정보보호학과",
-  "사물인터넷학과",
-  "메타버스게임학과",
-];
-
-const DepartmentSelect = ({ control }: { control: any }) => (
-  <FormField
-    control={control}
-    name="department"
-    render={({ field }) => (
-      <FormItem>
-        <FormLabel>학과</FormLabel>
-        <Select onValueChange={field.onChange} defaultValue={field.value}>
-          <FormControl>
-            <SelectTrigger>
-              <SelectValue placeholder="학과를 선택하세요" />
-            </SelectTrigger>
-          </FormControl>
-          <SelectContent>
-            {departments.map((dept) => (
-              <SelectItem key={dept} value={dept}>
-                {dept}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <FormMessage />
-      </FormItem>
-    )}
-  />
-);
-
 export default function EditMyPage() {
   const router = useRouter();
   const { toast } = useToast();
@@ -89,8 +40,8 @@ export default function EditMyPage() {
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      studentId: "20204023",
-      department: "컴퓨터소프트웨어공학과",
+      username: "20204023",
+      department: departments[0].value,
       name: "황다경",
       email: "",
       phoneNumber: "",
@@ -120,11 +71,18 @@ export default function EditMyPage() {
         <div className="w-[328px] space-y-4">
           <TextField
             control={form.control}
-            name="studentId"
+            name="username"
             label="학번"
             disabled
           />
-          <DepartmentSelect control={form.control} />
+          <SelectField
+            control={form.control}
+            name="department"
+            label="학과"
+            options={departments}
+            placeholder="학과를 선택하세요"
+            disabled
+          />
           <TextField control={form.control} name="name" label="이름" disabled />
           <TextField
             control={form.control}

--- a/src/app/(user)/user/mypage/edit/page.tsx
+++ b/src/app/(user)/user/mypage/edit/page.tsx
@@ -10,35 +10,17 @@ import { useToast } from "@/hooks/use-toast";
 import { TextField, PasswordField, SelectField } from "@/components/FormField";
 import { Device } from "@/components/Device";
 import { departments } from "@/constants/constants";
-const formSchema = z
-  .object({
-    username: z.string(),
-    department: z.string(),
-    name: z.string(),
-    email: z.string().email({ message: "유효한 이메일 주소를 입력해주세요." }),
-    phoneNumber: z
-      .string()
-      .min(10, { message: "올바른 전화번호를 입력해주세요." }),
-    password: z.string().min(6, { message: "현재 비밀번호를 입력해주세요." }),
-    newPassword: z
-      .string()
-      .min(6, { message: "새 비밀번호는 최소 6자 이상이어야 합니다." }),
-    confirmPassword: z.string(),
-    devices: z
-      .array(z.string())
-      .max(2, "최대 2개의 디바이스만 등록할 수 있습니다."),
-  })
-  .refine((data) => data.newPassword === data.confirmPassword, {
-    message: "새 비밀번호가 일치하지 않습니다.",
-    path: ["confirmPassword"],
-  });
+import {
+  EditProfileSchema,
+  EditProfileFormData,
+} from "@/schemas/editProfileSchema";
 
 export default function EditMyPage() {
   const router = useRouter();
   const { toast } = useToast();
 
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
+  const form = useForm<EditProfileFormData>({
+    resolver: zodResolver(EditProfileSchema),
     defaultValues: {
       username: "20204023",
       department: departments[0].value,
@@ -52,7 +34,7 @@ export default function EditMyPage() {
     },
   });
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
+  function onSubmit(values: EditProfileFormData) {
     console.log(values);
     toast({
       title: "정보가 수정되었습니다.",

--- a/src/app/(user)/user/mypage/edit/page.tsx
+++ b/src/app/(user)/user/mypage/edit/page.tsx
@@ -1,37 +1,63 @@
 "use client";
 
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
 import { useToast } from "@/hooks/use-toast";
-import { TextField, PasswordField, SelectField } from "@/components/FormField";
+import { TextField, PasswordField } from "@/components/FormField";
 import { Device } from "@/components/Device";
 import { departments } from "@/constants/constants";
 import {
   EditProfileSchema,
   EditProfileFormData,
 } from "@/schemas/editProfileSchema";
+import { useUserInfo } from "@/hooks/useUserInfo";
 
 export default function EditMyPage() {
   const router = useRouter();
   const { toast } = useToast();
+  const { userInfo, isLoading } = useUserInfo();
 
   const form = useForm<EditProfileFormData>({
     resolver: zodResolver(EditProfileSchema),
     defaultValues: {
-      username: "20204023",
-      department: departments[0].value,
-      name: "황다경",
-      email: "",
-      phoneNumber: "",
+      username: userInfo?.username || "",
+      department: userInfo?.department || "",
+      name: userInfo?.name || "",
+      email: userInfo?.email || "",
+      phoneNumber: userInfo?.phoneNumber || "",
       password: "",
       newPassword: "",
       confirmPassword: "",
       devices: [""],
     },
   });
+
+  useEffect(() => {
+    if (userInfo) {
+      const departmentName =
+        departments.find((dept) => dept.value === userInfo.department)?.label ||
+        userInfo.department;
+      form.reset({
+        username: userInfo.username,
+        department: departmentName,
+        name: userInfo.name,
+        email: userInfo.email,
+        phoneNumber: userInfo.phoneNumber,
+        password: "",
+        newPassword: "",
+        confirmPassword: "",
+        devices: [""],
+      });
+    }
+  }, [userInfo, form]);
+
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
 
   function onSubmit(values: EditProfileFormData) {
     console.log(values);
@@ -56,12 +82,10 @@ export default function EditMyPage() {
             label="학번"
             disabled
           />
-          <SelectField
+          <TextField
             control={form.control}
             name="department"
             label="학과"
-            options={departments}
-            placeholder="학과를 선택하세요"
             disabled
           />
           <TextField control={form.control} name="name" label="이름" disabled />

--- a/src/app/(user)/user/mypage/page.tsx
+++ b/src/app/(user)/user/mypage/page.tsx
@@ -9,9 +9,9 @@ import { useRouter } from "next/navigation";
 import axios from "axios";
 
 interface UserInfo {
-  name: string;   
-  department: string;   
-  studentId: string;  
+  name: string;
+  department: string;
+  username: string;
 }
 
 export default function MyPage() {
@@ -46,7 +46,7 @@ export default function MyPage() {
     };
     fetchUserInfo();
   }, [router]);
-  
+
   return (
     <main className="relative flex flex-col items-center">
       <div className="relative">
@@ -54,7 +54,7 @@ export default function MyPage() {
         <div className="absolute top-4 right-4 text-right text-white">
           <p className="font-bold text-2xl">{userInfo?.name}</p>
           <p className="text-base">{userInfo?.department}</p>
-          <p className="text-base">{userInfo?.studentId}</p>
+          <p className="text-base">{userInfo?.username}</p>
         </div>
       </div>
       <Link href="/user/mypage/edit" passHref>

--- a/src/app/(user)/user/mypage/page.tsx
+++ b/src/app/(user)/user/mypage/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Edit } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useUserInfo } from "@/hooks/useUserInfo";
@@ -9,6 +10,7 @@ import { departments } from "@/constants/constants";
 
 export default function MyPage() {
   const { userInfo, isLoading } = useUserInfo();
+  const router = useRouter();
 
   if (isLoading) {
     return <div>로딩 중...</div>;
@@ -17,6 +19,12 @@ export default function MyPage() {
   const departmentName =
     departments.find((dept) => dept.value === userInfo?.department)?.label ||
     userInfo?.department;
+
+  const handleLogout = () => {
+    // 로컬 스토리지에서 토큰 제거
+    localStorage.removeItem("accessToken");
+    router.push("/");
+  };
 
   return (
     <main className="relative flex flex-col items-center">
@@ -34,6 +42,18 @@ export default function MyPage() {
           수정하기
         </Button>
       </Link>
+
+      <div className="mt-8 flex gap-4">
+        <Link href="/admin" className="text-gray-500 hover:underline">
+          관리자 페이지
+        </Link>
+        <div className="text-gray-500"> | </div>
+        <button
+          onClick={handleLogout}
+          className="text-gray-500 hover:underline">
+          로그아웃
+        </button>
+      </div>
     </main>
   );
 }

--- a/src/app/(user)/user/mypage/page.tsx
+++ b/src/app/(user)/user/mypage/page.tsx
@@ -4,48 +4,19 @@ import Image from "next/image";
 import Link from "next/link";
 import { Edit } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import axios from "axios";
-
-interface UserInfo {
-  name: string;
-  department: string;
-  username: string;
-}
+import { useUserInfo } from "@/hooks/useUserInfo";
+import { departments } from "@/constants/constants";
 
 export default function MyPage() {
-  const router = useRouter();
-  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const { userInfo, isLoading } = useUserInfo();
 
-  useEffect(() => {
-    const accessToken = localStorage.getItem("accessToken");
-    if (!accessToken) {
-      router.push("/login");
-      return;
-    }
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
 
-    const fetchUserInfo = async () => {
-      try {
-        const response = await axios.get(
-          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/users/profile`,
-          {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-            },
-          }
-        );
-        setUserInfo(response.data);
-      } catch (error) {
-        console.error("사용자 정보 조회 실패:", error);
-        router.push("/login");
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    fetchUserInfo();
-  }, [router]);
+  const departmentName =
+    departments.find((dept) => dept.value === userInfo?.department)?.label ||
+    userInfo?.department;
 
   return (
     <main className="relative flex flex-col items-center">
@@ -53,7 +24,7 @@ export default function MyPage() {
         <Image src="/assets/Card.png" alt="카드" width={332} height={480} />
         <div className="absolute top-4 right-4 text-right text-white">
           <p className="font-bold text-2xl">{userInfo?.name}</p>
-          <p className="text-base">{userInfo?.department}</p>
+          <p className="text-base">{departmentName}</p>
           <p className="text-base">{userInfo?.username}</p>
         </div>
       </div>

--- a/src/components/Device.tsx
+++ b/src/components/Device.tsx
@@ -54,7 +54,7 @@ export const Device = ({ control }: DeviceProps) => {
           type="button"
           variant="outline"
           size="sm"
-          className="mt-2 w-full"
+          className="mt-2 w-full mb-4"
           onClick={() => append("")}>
           <PlusCircle className="h-4 w-4 mr-2" />
           디바이스 추가

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -21,6 +21,7 @@ interface InputFieldProps {
   label: string;
   type?: string;
   placeholder?: string;
+  disabled?: boolean;
 }
 
 export const InputField = ({
@@ -28,6 +29,7 @@ export const InputField = ({
   name,
   label,
   type = "text",
+  disabled,
   ...props
 }: InputFieldProps) => (
   <FormField
@@ -37,7 +39,13 @@ export const InputField = ({
       <FormItem>
         <FormLabel>{label}</FormLabel>
         <FormControl>
-          <Input {...field} type={type} className="w-full" {...props} />
+          <Input
+            {...field}
+            type={type}
+            className="w-full"
+            {...props}
+            disabled={disabled}
+          />
         </FormControl>
         <FormMessage />
       </FormItem>
@@ -57,6 +65,7 @@ interface SelectFieldProps {
   control: Control<any>;
   options: { value: string; label: string }[];
   placeholder?: string;
+  disabled?: boolean;
 }
 
 export const SelectField: React.FC<SelectFieldProps> = ({
@@ -65,6 +74,7 @@ export const SelectField: React.FC<SelectFieldProps> = ({
   control,
   options,
   placeholder,
+  disabled,
 }) => {
   return (
     <FormField
@@ -73,7 +83,10 @@ export const SelectField: React.FC<SelectFieldProps> = ({
       render={({ field }) => (
         <FormItem>
           <FormLabel>{label}</FormLabel>
-          <Select onValueChange={field.onChange} defaultValue={field.value}>
+          <Select
+            onValueChange={field.onChange}
+            defaultValue={field.value}
+            disabled={disabled}>
             <FormControl>
               <SelectTrigger>
                 <SelectValue placeholder={placeholder} />

--- a/src/constants/constants.tsx
+++ b/src/constants/constants.tsx
@@ -1,0 +1,8 @@
+export const departments = [
+  { label: "컴퓨터소프트웨어공학과", value: "CSE" },
+  { label: "의료 IT공학과", value: "MEDIT" },
+  { label: "정보보호학과", value: "IP" },
+  { label: "사물인터넷학과", value: "IoT" },
+  { label: "메타버스게임학과", value: "METABUS" },
+  { label: "AI빅데이터공학과", value: "AI_BIGDATA" },
+];

--- a/src/hooks/useUserInfo.ts
+++ b/src/hooks/useUserInfo.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect } from "react";
+import axios from "axios";
+import { useRouter } from "next/navigation";
+
+export interface UserInfo {
+  name: string;
+  department: string;
+  username: string;
+  email: string;
+  phoneNumber: string;
+}
+
+export function useUserInfo() {
+  const router = useRouter();
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      const accessToken = localStorage.getItem("accessToken");
+      if (!accessToken) {
+        router.push("/login");
+        return;
+      }
+
+      try {
+        const response = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/users/profile`,
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        );
+        setUserInfo(response.data);
+      } catch (error) {
+        console.error("사용자 정보 조회 실패:", error);
+        router.push("/login");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchUserInfo();
+  }, [router]);
+
+  return { userInfo, isLoading };
+}

--- a/src/hooks/useUserInfo.ts
+++ b/src/hooks/useUserInfo.ts
@@ -8,6 +8,7 @@ export interface UserInfo {
   username: string;
   email: string;
   phoneNumber: string;
+  password: string;
 }
 
 export function useUserInfo() {

--- a/src/hooks/useUserInfo.ts
+++ b/src/hooks/useUserInfo.ts
@@ -8,7 +8,7 @@ export interface UserInfo {
   username: string;
   email: string;
   phoneNumber: string;
-  password: string;
+  devices: string[];
 }
 
 export function useUserInfo() {

--- a/src/schemas/editProfileSchema.ts
+++ b/src/schemas/editProfileSchema.ts
@@ -5,22 +5,50 @@ export const EditProfileSchema = z
     username: z.string(),
     department: z.string(),
     name: z.string(),
-    email: z.string().email({ message: "유효한 이메일 주소를 입력해주세요." }),
+    email: z
+      .string()
+      .email({ message: "유효한 이메일 주소를 입력해주세요." })
+      .or(z.literal("")),
     phoneNumber: z
       .string()
-      .min(10, { message: "올바른 전화번호를 입력해주세요." }),
-    password: z.string().min(6, { message: "현재 비밀번호를 입력해주세요." }),
+      .min(10, { message: "올바른 전화번호를 입력해주세요." })
+      .or(z.literal("")),
+    currentPassword: z
+      .string()
+      .min(1, "현재 비밀번호를 입력해주세요.")
+      .or(z.literal("")),
     newPassword: z
       .string()
-      .min(6, { message: "새 비밀번호는 최소 6자 이상이어야 합니다." }),
-    confirmPassword: z.string(),
+      .min(6, "새 비밀번호는 최소 6자 이상이어야 합니다.")
+      .or(z.literal("")),
+    confirmPassword: z.string().or(z.literal("")),
     devices: z
       .array(z.string())
       .max(2, "최대 2개의 디바이스만 등록할 수 있습니다."),
   })
-  .refine((data) => data.newPassword === data.confirmPassword, {
-    message: "새 비밀번호가 일치하지 않습니다.",
-    path: ["confirmPassword"],
-  });
+  .refine(
+    (data) => {
+      if (data.newPassword) {
+        return data.newPassword === data.confirmPassword;
+      }
+      return true;
+    },
+    {
+      message: "새 비밀번호가 일치하지 않습니다.",
+      path: ["confirmPassword"],
+    }
+  )
+  .refine(
+    (data) => {
+      if (data.newPassword) {
+        return !!data.currentPassword;
+      }
+      return true;
+    },
+    {
+      message: "새 비밀번호를 설정하려면 현재 비밀번호를 입력해야 합니다.",
+      path: ["currentPassword"],
+    }
+  );
 
 export type EditProfileFormData = z.infer<typeof EditProfileSchema>;

--- a/src/schemas/editProfileSchema.ts
+++ b/src/schemas/editProfileSchema.ts
@@ -1,0 +1,26 @@
+import * as z from "zod";
+
+export const EditProfileSchema = z
+  .object({
+    username: z.string(),
+    department: z.string(),
+    name: z.string(),
+    email: z.string().email({ message: "유효한 이메일 주소를 입력해주세요." }),
+    phoneNumber: z
+      .string()
+      .min(10, { message: "올바른 전화번호를 입력해주세요." }),
+    password: z.string().min(6, { message: "현재 비밀번호를 입력해주세요." }),
+    newPassword: z
+      .string()
+      .min(6, { message: "새 비밀번호는 최소 6자 이상이어야 합니다." }),
+    confirmPassword: z.string(),
+    devices: z
+      .array(z.string())
+      .max(2, "최대 2개의 디바이스만 등록할 수 있습니다."),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "새 비밀번호가 일치하지 않습니다.",
+    path: ["confirmPassword"],
+  });
+
+export type EditProfileFormData = z.infer<typeof EditProfileSchema>;

--- a/src/schemas/signinSchema.ts
+++ b/src/schemas/signinSchema.ts
@@ -1,0 +1,21 @@
+import * as z from "zod";
+
+export const SigninSchema = z
+  .object({
+    username: z.string().length(8, {
+      message: "학번 8자리를 입력해주세요.",
+    }),
+    department: z.string().min(1, "학과를 선택해주세요"),
+    name: z.string().min(1, "이름을 입력해주세요"),
+    password: z.string().min(6, {
+      message: "비밀번호는 최소 6자 이상이어야 합니다.",
+    }),
+    confirmPassword: z.string(),
+    role: z.enum(["STUDENT", "ADMIN"]),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "비밀번호가 일치하지 않습니다.",
+    path: ["confirmPassword"],
+  });
+
+export type SigninFormData = z.infer<typeof SigninSchema>;


### PR DESCRIPTION
## 💡 핵심 변경사항

- mypage, editpage에서 공통 사용하는 departments를 containts.tsx 재사용 가능하게 분리하였습니다.
- 폼 스키마를 분리하여 코드 가독성을 향상시켰습니다.
- mypage, editpage에서 사용하는 프로필 호출 api를 hooks/useUserInfo로 분리하였습니다.
- 기존 유효성 검사 로직에서 빈 문자열을 허용하는 방향으로 로직을 수정하였습니다.
- 비밀번호 변경 api 연동하여, 비밀번호 변경되도록 구현하였으며, 이와 관련하여 400, 403 코드에 대한 에러 처리 및 현재 비밀번호, 새 비밀번호 등의 유효성 처리를 강화하였습니다.
- mypage, editpage에서 플로팅 버튼이 나타나지 않도록 레이아웃 수정하였습니다.
- mypage에서 관리자 페이지로 이동하는 버튼, 로그아웃 버튼 추가하였습니다.

## 📷 구현 결과
![image](https://github.com/user-attachments/assets/df608047-47aa-4f22-a1ca-2d521fc66662)


## 🧐 추가 논의사항, 개선 필요 사항
- 비밀번호 변경 및 유효성 처리를 하나의 파일 내에서 처리 중이어서 복잡합니다. 컴포넌트 분리가 필요합니다. 추후 사용자 프로필 수정(전화번호, 이메일, 디바이스 등) api 연동 완료 후, 컴포넌트 분리 작업 진행하겠습니다.
- 로그아웃 기능의 경우 로컬 스토리지에서 토큰을 제거하는 방식으로 구현하였습니다. 로그아웃 로직 관련 논의가 필요합니다. 로그아웃 api를 개발하여 연동할 것인지, 아니면 프론트에서 next/auth를 사용하는 방법 또는 토큰 만료 방식을 사용할 것인지...
